### PR TITLE
Replace langchain utils usage

### DIFF
--- a/recipes/Basics/RAG_with_Langchain.ipynb
+++ b/recipes/Basics/RAG_with_Langchain.ipynb
@@ -102,21 +102,12 @@
    "source": [
     "! pip install \\\n",
     "  \"git+https://github.com/ibm-granite-community/utils.git\" \\\n",
-    "  \"langchain-core\" \\\n",
-    "  \"langchain\" \\\n",
-    "  \"ibm-watsonx-ai\" \\\n",
-    "  \"langchain_ibm\" \\\n",
-    "  \"wget\" \\\n",
-    "  \"pydantic\" \\\n",
-    "  \"sqlalchemy\" \\\n",
-    "  \"langchain-community\" \\\n",
-    "  \"langchain-huggingface\" \\\n",
-    "  \"pinecone\""
+    "  \"wget\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +132,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    " LangChain retrievals use `embed_documents` and `embed_query` under the hood to generate embedding vectors for uploaded documents and user query respectively."
+    "Specify the model to use for generating embeddings from text.\n",
+    "\n",
+    "To use a model from a provider other than Huggingface, replace this code cell with one from [this Embeddings Model recipe](https://github.com/ibm-granite-community/utils/blob/main/recipes/Components/Langchain_Embeddings_Models.ipynb)."
    ]
   },
   {
@@ -158,7 +151,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Choose your Vector Database"
+    "### Choose your Vector Database\n",
+    "\n",
+    "Specify the database to use for storing and retrieving embedding vectors.\n",
+    "\n",
+    "To connect to a vector database other than Milvus substitute this code cell with one from [this Vector Store recipe](https://github.com/ibm-granite-community/utils/blob/main/recipes/Components/Langchain_Vector_Stores.ipynb)."
    ]
   },
   {
@@ -167,14 +164,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import random, string\n",
-    "vector_db_provider = \"milvus\"\n",
+    "from langchain_milvus import Milvus\n",
+    "import uuid\n",
     "\n",
-    "# Generate random filename for the milvus db\n",
-    "db_file = f\"/tmp/milvus_{''.join(random.choices(string.ascii_lowercase + string.digits, k=10))}.db\"\n",
+    "db_file = f\"/tmp/milvus_{str(uuid.uuid4())[:8]}.db\"\n",
     "print(f\"The vector database will be saved to {db_file}\")\n",
     "\n",
-    "vector_db = find_langchain_vector_db(vector_db_provider, embeddings_model, connection_args={\"uri\": db_file}, auto_id=True)"
+    "vector_db = Milvus(embedding_function=embeddings_model, connection_args={\"uri\": db_file}, auto_id=True)"
    ]
   },
   {
@@ -190,18 +186,24 @@
    },
    "source": [
     "### Choose your LLM\n",
-    "Specify the model that will be used for inferencing."
+    "Specify the model that will be used for inferencing.\n",
+    "\n",
+    "To connect to a model on a provider other than Replicate, substitute this code cell with one from [this LLM component recipe](https://github.com/ibm-granite-community/utils/blob/main/recipes/Components/Langchain_LLMs.ipynb)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_id = \"ibm-granite/granite-8b-code-instruct-128k\"\n",
+    "from langchain_community.llms import Replicate\n",
+    "from ibm_granite_community.notebook_utils import get_env_var\n",
     "\n",
-    "llm = find_langchain_model(\"replicate\", model_id)"
+    "model = Replicate(\n",
+    "    model=\"ibm-granite/granite-8b-code-instruct-128k\",\n",
+    "    model_kwargs={\"apikey\": get_env_var('REPLICATE_API_TOKEN')},\n",
+    ")"
    ]
   },
   {
@@ -232,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -264,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -357,13 +359,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
     "from langchain.chains import RetrievalQA\n",
     "\n",
-    "qa = RetrievalQA.from_chain_type(llm=llm, chain_type=\"stuff\", retriever=vector_db.as_retriever()) # , chain_type_kwargs={\"verbose\": False})"
+    "qa = RetrievalQA.from_chain_type(llm=model, chain_type=\"stuff\", retriever=vector_db.as_retriever()) # , chain_type_kwargs={\"verbose\": False})"
    ]
   },
   {

--- a/recipes/Basics/RAG_with_Langchain.ipynb
+++ b/recipes/Basics/RAG_with_Langchain.ipynb
@@ -132,7 +132,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Specify the model to use for generating embeddings from text.\n",
+    "Specify the model to use for generating embedding vectors from text.\n",
     "\n",
     "To use a model from a provider other than Huggingface, replace this code cell with one from [this Embeddings Model recipe](https://github.com/ibm-granite-community/utils/blob/main/recipes/Components/Langchain_Embeddings_Models.ipynb)."
    ]
@@ -186,7 +186,7 @@
    },
    "source": [
     "### Choose your LLM\n",
-    "Specify the model that will be used for inferencing.\n",
+    "Specify the model that will be used for inferencing, given a query and the retrieved text.\n",
     "\n",
     "To connect to a model on a provider other than Replicate, substitute this code cell with one from [this LLM component recipe](https://github.com/ibm-granite-community/utils/blob/main/recipes/Components/Langchain_LLMs.ipynb)."
    ]


### PR DESCRIPTION
[#134](https://github.com/ibm-granite-community/pm/issues/134):
- Replace find_langchain_model with LLM component
- Replace find_langchain_vector_db with Vector DB component