### PR TITLE
Fixed replicate token passing for RAG.

### DIFF
--- a/recipes/Basics/RAG_with_Langchain.ipynb
+++ b/recipes/Basics/RAG_with_Langchain.ipynb
@@ -106,15 +106,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ibm_granite_community.langchain_utils import find_langchain_model, find_langchain_vector_db"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -193,16 +184,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "from langchain_community.llms import Replicate\n",
-    "from ibm_granite_community.notebook_utils import get_env_var\n",
+    "from ibm_granite_community.notebook_utils import get_env_var, set_env_var\n",
+    "\n",
+    "set_env_var(\"REPLICATE_API_TOKEN\")\n",
     "\n",
     "model = Replicate(\n",
     "    model=\"ibm-granite/granite-8b-code-instruct-128k\",\n",
-    "    replicate_api_token=get_env_var('REPLICATE_API_TOKEN'),\n",
     ")"
    ]
   },
@@ -234,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -266,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -299,7 +291,7 @@
     }
    },
    "source": [
-    "### Create and populate the vector database\n",
+    "### Populate the vector database\n",
     "\n",
     "NOTE: Population of the vector database may take over a minute depending on your embedding model and service."
    ]
@@ -310,7 +302,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# vector_db = vector_db_class.from_documents(texts, embeddings)\n",
     "vector_db.add_documents(texts)"
    ]
   },
@@ -359,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
- Pass the `REPLICATE_API_TOKEN` implicitly via env var, for RetrievalQA to work.
- Also remove langchain_utils imports.