### PR TITLE
Fix recipe to use get_env_var

### DIFF
--- a/recipes/RAG/RAG_over_NH_Caselaw_Summarize.ipynb
+++ b/recipes/RAG/RAG_over_NH_Caselaw_Summarize.ipynb
@@ -192,9 +192,9 @@
    "outputs": [],
    "source": [
     "from langchain_community.llms import Replicate\n",
-    "from ibm_granite_community.notebook_utils import set_env_var\n",
+    "from ibm_granite_community.notebook_utils import get_env_var\n",
     "\n",
-    "set_env_var(\"REPLICATE_API_TOKEN\")\n",
+    "get_env_var(\"REPLICATE_API_TOKEN\")\n",
     "\n",
     "model = Replicate(\n",
     "    model=\"ibm-granite/granite-3.0-8b-instruct\",\n",
@@ -644,11 +644,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -658,8 +653,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## PR Checklist

### Notebook requirements

- [x] **Notebook outputs cleared**: Ensure all notebook outputs are cleared.
- [x] **Standard access to secrets and variables** Include `!pip install git+https://github.com/ibm-granite-community/utils` in the first code cell in order to make `get_env_var` available to accessing secrets and variables in the recipe.

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
