### PR TITLE
Fix for latest langchain_milvus

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # Run `pre-commit install` to activate pre-commit hooks
 repos:
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.8.1
     hooks:
       - id: nbstripout
         args: [

--- a/recipes/RAG/RAG_over_NH_Caselaw_Summarize.ipynb
+++ b/recipes/RAG/RAG_over_NH_Caselaw_Summarize.ipynb
@@ -162,12 +162,17 @@
    "outputs": [],
    "source": [
     "from langchain_milvus import Milvus\n",
-    "import uuid\n",
+    "import tempfile\n",
     "\n",
-    "db_file = f\"/tmp/milvus_{str(uuid.uuid4())[:8]}.db\"\n",
+    "db_file = tempfile.NamedTemporaryFile(prefix=\"milvus_\", suffix=\".db\", delete=False).name\n",
     "print(f\"The vector database will be saved to {db_file}\")\n",
     "\n",
-    "vector_db = Milvus(embedding_function=embeddings_model, connection_args={\"uri\": db_file}, auto_id=True)"
+    "vector_db = Milvus(\n",
+    "    embedding_function=embeddings_model,\n",
+    "    connection_args={\"uri\": db_file},\n",
+    "    auto_id=True,\n",
+    "    index_params={\"index_type\": \"AUTOINDEX\"},\n",
+    ")"
    ]
   },
   {
@@ -653,11 +658,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -667,8 +667,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The change to langchain_milvus 0.1.8 no longer falls back to AUTOINDEX for local db. So we must specify it as the default index_type is not supported for local db.

## PR Checklist

### Notebook requirements

- [x] **Notebook outputs cleared**: Ensure all notebook outputs are cleared.

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
